### PR TITLE
Fixed icon_url for uWave

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -59,7 +59,7 @@
     "url":
       "https://uwave.sg/download",
     "icon_url":
-      "https://assets.getpebble.com/api/file/PYUmPYRjSKqAtYfXdUv9/convert?cache=true&fit=crop&w=144&h=168",
+      "https://play-lh.googleusercontent.com/a9mD7W6FDPFmGVllWCcja_3I9ynoHHSITEn_bVhq01X7aHMXC-tv8SKCDxLu04Q6-6U%3Ds360-rw",
     "tags": ["productivity", "education", "lifestyle", "bus", "stop"]
   }
 ]


### PR DESCRIPTION
With reference to: https://github.com/nusmodifications/nusmods-apps/pull/13