### PR TITLE
Removing apps that no longer exist

### DIFF
--- a/apps.json
+++ b/apps.json
@@ -52,30 +52,11 @@
     "tags": ["car", "carparks", "vehicles"]
   },
   {
-    "name": "uWave",
-    "description":
-      "uWave is a student all-in-one mobile app 📆 Student Timetable, ⏱ Finals countdown in Timetable, 🚌 Public Bus Timings + Campus Shuttle Location, 📍 NUS Campus Maps, 💬 NUS Discussions, 🏓 List of all CCAs in NUS, 🧧 Student discounts",
-    "author": "Wave",
-    "url":
-      "https://uwave.sg/download",
-    "icon_url":
-      "https://play-lh.googleusercontent.com/a9mD7W6FDPFmGVllWCcja_3I9ynoHHSITEn_bVhq01X7aHMXC-tv8SKCDxLu04Q6-6U%3Ds360-rw",
-    "tags": ["productivity", "education", "lifestyle", "bus", "stop"]
-  },
-  {
     "name": "From The Future",
     "description": "A simple & easy way to add & view advice for NUS Computing freshmen.",
     "author": "Liu Yongliang",
     "url": "https://tlylt.github.io/from-the-future/",
     "icon_url": "https://raw.githubusercontent.com/tlylt/from-the-future/master/public/android-chrome-512x512.png",
     "tags": ["education", "life", "advice"]
-  },
-  {
-    "name": "NUSAbroad",
-    "description": "Compare universities, find past mappings and plan your exchange application, right here at NUSAbroad.",
-    "author": "Audrey Felicio Anwar, Chester How, Dylan Ghee and Goh Wen Hao",
-    "url": "https://nusabroad.com",
-    "icon_url": "https://i.imgur.com/NQ1yIii.png",
-    "tags": ["exchange", "SEP", "planner"]
   }
 ]


### PR DESCRIPTION
Specifically, uWave and NUSAbroad. You can reject this if there are alternative links that work.